### PR TITLE
fix: renamed white and black (opacity options), added typography

### DIFF
--- a/components/postcss.config.js
+++ b/components/postcss.config.js
@@ -1,6 +1,0 @@
-import tailwindcss from "tailwindcss"
-import autoprefixer from "autoprefixer"
-
-export default {
-  plugins: [tailwindcss("./tailwind.config.ts"), autoprefixer],
-}

--- a/components/tailwind.config.cjs
+++ b/components/tailwind.config.cjs
@@ -2,10 +2,10 @@
 module.exports = {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    fontFamily: {
-      roboto: ["Roboto", "sans-serif"],
-    },
     extend: {
+      fontFamily: {
+        roboto: ["Roboto", "sans-serif"],
+      },
       colors: {
         common: {
           black: "#000",
@@ -21,7 +21,7 @@ module.exports = {
           200: "#E4E4E4",
           300: "#CFCFCF",
           400: "#BBB",
-          500: "#7f7f7f",
+          500: "#7F7F7F",
           600: "#6B6B6B",
           700: "#555555",
           800: "#4D4D4D",
@@ -66,15 +66,15 @@ module.exports = {
           main: "#FF274B",
           light: "#FF6877",
         },
-        white: {
-          primary: "rgba(255, 255, 255, 0.95)",
-          secondary: "rgba(255, 255, 255, 0.83)",
-          disabled: "rgba(255, 255, 255, 0.38)",
+        "opacity-white": {
+          95: "rgba(255, 255, 255, 0.95)",
+          83: "rgba(255, 255, 255, 0.83)",
+          38: "rgba(255, 255, 255, 0.38)",
         },
-        black: {
-          primary: "rgba(0, 0, 0, 0.95)",
-          secondary: "rgba(0, 0, 0, 0.83)",
-          disabled: "rgba(0, 0, 0, 0.38)",
+        "opacity-black": {
+          95: "rgba(0, 0, 0, 0.95)",
+          83: "rgba(0, 0, 0, 0.83)",
+          38: "rgba(0, 0, 0, 0.38)",
         },
       },
     },

--- a/components/tsconfig.node.json
+++ b/components/tsconfig.node.json
@@ -5,5 +5,5 @@
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "tailwind.config.ts", "postcss.config.js"]
+  "include": ["vite.config.ts"]
 }

--- a/components/vite.config.ts
+++ b/components/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vitest/config"
 import react from "@vitejs/plugin-react"
 import { resolve } from "path"
+import tailwindcss from "tailwindcss"
+import autoprefixer from "autoprefixer"
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -16,6 +18,11 @@ export default defineConfig({
       name: "components",
       // the proper extensions will be added
       fileName: "components",
+    },
+  },
+  css: {
+    postcss: {
+      plugins: [tailwindcss(), autoprefixer],
     },
   },
 })

--- a/docs/.storybook/preview-head.html
+++ b/docs/.storybook/preview-head.html
@@ -1,5 +1,9 @@
 <!-- ./storybook/preview-head.html -->
 <link href="./src/index.css" rel="stylesheet" />
+<link
+  href="https://fonts.googleapis.com/css2?family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
+  rel="stylesheet"
+/>
 <script>
-  window.global = window;
+  window.global = window
 </script>

--- a/docs/postcss.config.cjs
+++ b/docs/postcss.config.cjs
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -3,6 +3,9 @@ module.exports = {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
+      fontFamily: {
+        roboto: ["Roboto", "sans-serif"],
+      },
       colors: {
         common: {
           black: "#000",
@@ -63,15 +66,15 @@ module.exports = {
           main: "#FF274B",
           light: "#FF6877",
         },
-        white: {
-          primary: "rgba(255, 255, 255, 0.95)",
-          secondary: "rgba(255, 255, 255, 0.83)",
-          disabled: "rgba(255, 255, 255, 0.38)",
+        "opacity-white": {
+          95: "rgba(255, 255, 255, 0.95)",
+          83: "rgba(255, 255, 255, 0.83)",
+          38: "rgba(255, 255, 255, 0.38)",
         },
-        black: {
-          primary: "rgba(0, 0, 0, 0.95)",
-          secondary: "rgba(0, 0, 0, 0.83)",
-          disabled: "rgba(0, 0, 0, 0.38)",
+        "opacity-black": {
+          95: "rgba(0, 0, 0, 0.95)",
+          83: "rgba(0, 0, 0, 0.83)",
+          38: "rgba(0, 0, 0, 0.38)",
         },
       },
     },

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
+import tailwindcss from "tailwindcss"
+import autoprefixer from "autoprefixer"
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  css: {
+    postcss: {
+      plugins: [tailwindcss(), autoprefixer],
+    },
+  },
 })


### PR DESCRIPTION
Renamed 'white' and 'back' to 'opacity-white' and 'opacity-black' respectively. Now the default color options 'white' and 'black' work as well as the options for 'opacity-white' and 'opacity-black'. Changed vite configuration. Added typography.